### PR TITLE
Allow all LPSolve verbosity levels.

### DIFF
--- a/pylpsolve/pylpsolve.pyx
+++ b/pylpsolve/pylpsolve.pyx
@@ -2263,8 +2263,8 @@ cdef class LP(object):
         ####################
         # Verbosity
 
-        if option_dict["verbosity"] not in [1,2,3,4,5]:
-            raise ValueError("Verbosity level must be 1,2,3,4, or 5 (highest).")
+        if option_dict["verbosity"] not in [0,1,2,3,4,5,6]:
+            raise ValueError("Verbosity level must be 0,1,2,3,4,5 or 6 (highest).")
 
         # Options are vetted now; basis and others might not be 
 


### PR DESCRIPTION
LPSolve allows between 0 and 6, not just 1-5.
