### PR TITLE
Raise when an unknown solution error code is returned.

### DIFF
--- a/pylpsolve/pylpsolve.pyx
+++ b/pylpsolve/pylpsolve.pyx
@@ -2551,6 +2551,7 @@ cdef class LP(object):
         elif ret == 13:
              # NOFEASFOUND (13)         No feasible B&B solution found
             raise LPException("Error 13: No feasible B&B solution found")
+        raise LPException("Error {}: Unknown error!".format(ret))
 
         # And we're done
 


### PR DESCRIPTION
To my knowledge the given codes are possibly comprehensive for `solve`; however `lpsolve.h` defines several other error codes and silently falling through seems like a dangerous default.
